### PR TITLE
bug fix - kerberos authentication

### DIFF
--- a/mssqlrelay/commands/check.py
+++ b/mssqlrelay/commands/check.py
@@ -206,7 +206,7 @@ class Check:
         if self._connection is not None:
             return self._connection
 
-        self._connection = MSSQL(self.target.target_ip, self.target.mssql_port)
+        self._connection = MSSQL(self.target.remote_name, int(self.target.mssql_port))
         self._connection.connect()
 
         return self._connection
@@ -280,7 +280,7 @@ class Check:
         try:
             success = False
             if self.target.do_kerberos:
-                success = self.connection.kerberos_login(self.target.mssql_db, self.target.username, self.target.password, self.target.domain, hashes=self.target.hashes, aesKey=self.target.aes)
+                success = self.connection.kerberosLogin(self.target.mssql_db, self.target.username, self.target.password, self.target.domain, hashes=self.target.hashes, aesKey=self.target.aes, kdcHost=self.target.dc_ip)
             else:
                 success = self.connection.login(self.target.mssql_db, self.target.username, self.target.password, self.target.domain, hashes=self.target.hashes, useWindowsAuth=self.target.windows_auth)
 

--- a/mssqlrelay/commands/check.py
+++ b/mssqlrelay/commands/check.py
@@ -206,7 +206,7 @@ class Check:
         if self._connection is not None:
             return self._connection
 
-        self._connection = MSSQL(self.target.remote_name, int(self.target.mssql_port))
+        self._connection = MSSQL(self.target.target_ip, int(self.target.mssql_port), self.target.remote_name)
         self._connection.connect()
 
         return self._connection

--- a/mssqlrelay/commands/checkall.py
+++ b/mssqlrelay/commands/checkall.py
@@ -87,6 +87,7 @@ class CheckAll:
                     self.target.hashes,
                     remote_name=instance.hostname,
                     do_kerberos=self.target.do_kerberos,
+                    no_pass=self.target.no_pass,
                     use_sspi=self.target.use_sspi,
                     windows_auth=self.target.windows_auth,
                     aes=self.target.aes,

--- a/mssqlrelay/commands/relay.py
+++ b/mssqlrelay/commands/relay.py
@@ -39,6 +39,7 @@ class MSSQLRelay:
         self.username = self.victimtarget.username
         self.password = self.victimtarget.password
         self.victim = self.victimtarget.target_ip
+        self.victim_remote_name=self.victimtarget.hostname,
         self.hashes = options.hashes
         self.aesKey = options.aes
         self.dc_ip = options.dc_ip
@@ -53,7 +54,7 @@ class MSSQLRelay:
 
     def trigger(self):
         logging.info("Authenticating to victim %s" % self.victim)
-        ms_sql = tds.MSSQL(self.victim, int(self.mssql_port))
+        ms_sql = tds.MSSQL(self.victim, int(self.mssql_port), self.victim_remote_name)
         ms_sql.connect()
 
         try:

--- a/mssqlrelay/lib/target.py
+++ b/mssqlrelay/lib/target.py
@@ -152,6 +152,7 @@ class Target:
         self.lmhash: str = None
         self.nthash: str = None
         self.do_kerberos: bool = False
+        self.no_pass: bool = False
         self.use_sspi: bool = False
         self.windows_auth: bool = True
         self.aes: str = None
@@ -266,6 +267,7 @@ class Target:
         self.nthash = nthash
         self.aes = options.aes
         self.do_kerberos = options.do_kerberos
+        self.no_pass = options.no_pass
         self.use_sspi = options.use_sspi
         self.windows_auth = options.windows_auth
         self.dc_ip = dc_ip


### PR DESCRIPTION
Hello,

There were some issues with the Kerberos authentication. 
However the fix only works on the newest impacket version. The minimum version present in pip and used by default (0.11.0) has an issue that has been fixed here: https://github.com/fortra/impacket/pull/1648. 
The changes don't affect the standard LDAP authentication. 

![image](https://github.com/CompassSecurity/mssqlrelay/assets/25101526/9a4743cc-0b99-4d97-bcf0-18b1b7e3e1f9)
![image](https://github.com/CompassSecurity/mssqlrelay/assets/25101526/c3aec458-a648-4a71-bb75-cec77bcb390c)

